### PR TITLE
Implement `Error` for `CreateModuleError`

### DIFF
--- a/wgsl_to_wgpu/Cargo.toml
+++ b/wgsl_to_wgpu/Cargo.toml
@@ -16,6 +16,7 @@ syn = "1.0"
 quote = "1.0"
 proc-macro2 = "1"
 prettyplease = "0.1.15"
+thiserror = "1"
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"

--- a/wgsl_to_wgpu/src/lib.rs
+++ b/wgsl_to_wgpu/src/lib.rs
@@ -17,19 +17,22 @@ use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use std::collections::BTreeMap;
 use syn::{Ident, Index};
+use thiserror::Error;
 
 mod wgsl;
 
 // TODO: Simplify these templates and indentation?
 // TODO: Structure the code to make it easier to imagine what the output will look like.
 /// Errors while generating Rust source for a WGSl shader module.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Error)]
 pub enum CreateModuleError {
     /// Bind group sets must be consecutive and start from 0.
     /// See `bind_group_layouts` for [wgpu::PipelineLayoutDescriptor].
+    #[error("bind groups are non-consecutive or do not start from 0")]
     NonConsecutiveBindGroups,
 
     /// Each binding resource must be associated with exactly one binding index.
+    #[error("duplicate binding found with index `{binding}`")]
     DuplicateBinding { binding: u32 },
 }
 


### PR DESCRIPTION
Implements [`Error`](https://doc.rust-lang.org/std/error/trait.Error.html) for `CreateModuleError`.

Alternatively I could also implement it by hand instead of using `thiserror`. I can also put it behind a crate feature if desired.
In any case `thiserror` won't add any dependency overhead, `naga` is already using it.