### PR TITLE
Use `wgpu-types` instead of `wgpu`

### DIFF
--- a/wgsl_to_wgpu/Cargo.toml
+++ b/wgsl_to_wgpu/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 [dependencies]
 naga = { version = "0.8.5", features = ["wgsl-in"] }
-wgpu = "0.12.0"
+wgpu-types = "0.12.0"
 indoc = "1.0"
 
 [dev-dependencies]

--- a/wgsl_to_wgpu/src/lib.rs
+++ b/wgsl_to_wgpu/src/lib.rs
@@ -10,6 +10,9 @@
 //! This project currently supports a small subset of WGSL types and doesn't enforce certain key properties such as field alignment.
 //! It may be necessary to disable running this function for shaders with unsupported types or features.
 //! The current implementation assumes all shader stages are part of a single WGSL source file.
+
+extern crate wgpu_types as wgpu;
+
 use indoc::{formatdoc, writedoc};
 use std::collections::BTreeMap;
 use std::fmt::Write;


### PR DESCRIPTION
This significantly cuts down on build dependencies. As far as I understand it, this crate shouldn't need any access to `wgpu` types.