### PR TITLE
Add `cargo:rerun-if-changed` to example

### DIFF
--- a/example/build.rs
+++ b/example/build.rs
@@ -1,6 +1,7 @@
 use std::fmt::Write;
 
 fn main() {
+    println!("cargo:rerun-if-changed=src/shader.wgsl");
     let wgsl_source = std::fs::read_to_string("src/shader.wgsl").unwrap();
 
     // Generate the Rust bindings and write to a file.


### PR DESCRIPTION
The example currently would not rebuild `shader.rs` if only `shader.wgsl` is changed.
Adding this line fixes that.

I think it's good to make potential users aware of this pitfall.