### PR TITLE
Require initialization of RenderPass

### DIFF
--- a/example/src/shader.rs
+++ b/example/src/shader.rs
@@ -198,3 +198,67 @@ pub fn create_pipeline_layout(device: &wgpu::Device) -> wgpu::PipelineLayout {
             },
         )
 }
+pub struct NeedsVertexBuffer0;
+pub struct NeedsBindGroup0;
+pub struct NeedsBindGroup1;
+pub struct Ready;
+pub struct EnhancedRenderPass<'rp, VB0, BG0, BG1> {
+    render_pass: wgpu::RenderPass<'rp>,
+    type_state: std::marker::PhantomData<(VB0, BG0, BG1)>,
+}
+impl<'rp> EnhancedRenderPass<'rp, NeedsVertexBuffer0, NeedsBindGroup0, NeedsBindGroup1> {
+    pub fn new(
+        encoder: &'rp mut wgpu::CommandEncoder,
+        desc: &wgpu::RenderPassDescriptor<'rp, '_>,
+    ) -> EnhancedRenderPass<'rp, NeedsVertexBuffer0, NeedsBindGroup0, NeedsBindGroup1> {
+        let render_pass = encoder.begin_render_pass(desc);
+        EnhancedRenderPass {
+            render_pass,
+            type_state: std::marker::PhantomData,
+        }
+    }
+}
+impl<'rp, VB0, BG0, BG1> EnhancedRenderPass<'rp, VB0, BG0, BG1> {
+    pub fn inner(&mut self) -> &mut wgpu::RenderPass<'rp> {
+        &mut self.render_pass
+    }
+    pub fn set_vertex_buffer_0(
+        mut self,
+        buffer_slice: wgpu::BufferSlice<'rp>,
+    ) -> EnhancedRenderPass<'rp, Ready, BG0, BG1> {
+        self.render_pass.set_vertex_buffer(0, buffer_slice);
+        EnhancedRenderPass {
+            render_pass: self.render_pass,
+            type_state: std::marker::PhantomData,
+        }
+    }
+    pub fn set_bind_group_0(
+        mut self,
+        bind_group: &'rp bind_groups::BindGroup0,
+    ) -> EnhancedRenderPass<'rp, VB0, Ready, BG1> {
+        bind_group.set(&mut self.render_pass);
+        EnhancedRenderPass {
+            render_pass: self.render_pass,
+            type_state: std::marker::PhantomData,
+        }
+    }
+    pub fn set_bind_group_1(
+        mut self,
+        bind_group: &'rp bind_groups::BindGroup1,
+    ) -> EnhancedRenderPass<'rp, VB0, BG0, Ready> {
+        bind_group.set(&mut self.render_pass);
+        EnhancedRenderPass {
+            render_pass: self.render_pass,
+            type_state: std::marker::PhantomData,
+        }
+    }
+}
+impl<'rp> EnhancedRenderPass<'rp, Ready, Ready, Ready> {
+    pub fn draw(
+        &mut self,
+        vertices: std::ops::Range<u32>,
+        instances: std::ops::Range<u32>,
+    ) {
+        self.render_pass.draw(vertices, instances);
+    }
+}

--- a/wgsl_to_wgpu/src/lib.rs
+++ b/wgsl_to_wgpu/src/lib.rs
@@ -29,6 +29,7 @@ use syn::{Ident, Index};
 use thiserror::Error;
 
 mod bindgroup;
+mod renderpass;
 mod structs;
 mod wgsl;
 
@@ -157,6 +158,11 @@ pub fn create_shader_module(
         }
     };
 
+    let enhanced_render_pass = renderpass::enhanced_render_pass(
+        wgsl::get_vertex_input_structs(&module).len(),
+        bind_group_data.len()
+    );
+
     let output = quote! {
         #(#structs)*
 
@@ -173,6 +179,8 @@ pub fn create_shader_module(
         #create_shader_module
 
         #create_pipeline_layout
+
+        #enhanced_render_pass
     };
     Ok(pretty_print(&output))
 }

--- a/wgsl_to_wgpu/src/renderpass.rs
+++ b/wgsl_to_wgpu/src/renderpass.rs
@@ -1,0 +1,113 @@
+use proc_macro2::{Literal, TokenStream};
+use quote::{format_ident, quote};
+
+/// The enhanced render pass is a wrapper around RenderPass that gives us type level
+/// state tailored to our particular shader. This lets us not only assure that our bind
+/// groups and vertex buffers are set before we can draw, but also prevents us from
+/// setting these in out-of-bounds slots or indexes.
+pub fn enhanced_render_pass(qty_vertex_buffers: usize, qty_bind_groups: usize) -> TokenStream {
+
+    let vertex_buffers = (0..qty_vertex_buffers)
+        .map(|idx| {
+            let vb = format_ident!("VB{}", idx);
+            quote!(#vb)
+        })
+        .collect::<Vec<_>>();
+    let bind_groups = (0..qty_bind_groups)
+        .map(|idx| {
+            let bg = format_ident!("BG{}", idx);
+            quote!(#bg)
+        }).collect::<Vec<_>>();
+    let mut type_params = vertex_buffers.clone();
+    type_params.append(&mut bind_groups.clone());
+
+
+    let needing_vertex_buffers = (0..qty_vertex_buffers)
+        .map(|idx| {
+            let vb = format_ident!("NeedsVertexBuffer{}", idx);
+            quote!(#vb)
+        })
+        .collect::<Vec<_>>();
+    let needing_bind_groups = (0..qty_bind_groups)
+        .map(|idx| {
+            let bg = format_ident!("NeedsBindGroup{}", idx);
+            quote!(#bg)
+        }).collect::<Vec<_>>();
+    let mut type_args_needy = needing_vertex_buffers.clone();
+    type_args_needy.append(&mut needing_bind_groups.clone());
+    let needy_structs = type_args_needy.clone().iter().map(|ts| quote!(pub struct #ts;)).collect::<Vec<_>>();
+
+
+    let vertex_setters = vertex_buffers.clone().iter().enumerate().map(|(i, type_param)| {
+        let fn_name = format_ident!("set_vertex_buffer_{}", i);
+        let mut type_params_after = type_params.clone();
+        type_params_after[i] = quote!(Ready);
+        let slot = Literal::u32_unsuffixed(i as u32);
+        quote! {
+            pub fn #fn_name(mut self, buffer_slice: wgpu::BufferSlice<'rp>) -> EnhancedRenderPass<'rp, #(#type_params_after),*> {
+                self.render_pass.set_vertex_buffer(#slot, buffer_slice);
+                EnhancedRenderPass {
+                    render_pass: self.render_pass,
+                    type_state: std::marker::PhantomData,
+                }
+            }
+        }
+    }).collect::<Vec<TokenStream>>();
+
+    let bind_group_setters = bind_groups.clone().iter().enumerate().map(|(i, type_param)| {
+        let fn_name = format_ident!("set_bind_group_{}", i);
+        let mut type_params_after = type_params.clone();
+        type_params_after[vertex_buffers.len() + i] = quote!(Ready);
+        let bg_name = format_ident!("BindGroup{}", i);
+        quote! {
+            pub fn #fn_name(mut self, bind_group: &'rp bind_groups::#bg_name) -> EnhancedRenderPass<'rp, #(#type_params_after),*> {
+                bind_group.set(&mut self.render_pass);
+                EnhancedRenderPass {
+                    render_pass: self.render_pass,
+                    type_state: std::marker::PhantomData,
+                }
+            }
+        }
+    }).collect::<Vec<TokenStream>>();
+
+    let type_args_all_ready = (0..type_params.len()).map(|_| quote!(Ready)).collect::<Vec<_>>();
+
+    quote! {
+        #(#needy_structs)*
+        pub struct Ready;
+        pub struct EnhancedRenderPass<'rp, #(#type_params),*> {
+            render_pass: wgpu::RenderPass<'rp>,
+            type_state: std::marker::PhantomData<(#(#type_params),*)>,
+        }
+        impl<'rp> EnhancedRenderPass<'rp, #(#type_args_needy),*> {
+            pub fn new(encoder: &'rp mut wgpu::CommandEncoder, desc: &wgpu::RenderPassDescriptor<'rp, '_>) -> EnhancedRenderPass<'rp, #(#type_args_needy),*> {
+                let render_pass = encoder.begin_render_pass(desc);
+                EnhancedRenderPass {
+                    render_pass,
+                    type_state: std::marker::PhantomData,
+                }
+            }
+        }
+        impl<'rp, #(#type_params),*> EnhancedRenderPass<'rp, #(#type_params),*> {
+
+            // Tentative Goal:
+            // Adequately wrap RenderPass that this method is almost never necessary.
+            //
+            // Restraint:
+            // Never fully get rid of this method because there are probably lots
+            // of extensions on RenderPass out there that people want to keep access to.
+            pub fn inner(&mut self) -> &mut wgpu::RenderPass<'rp> {
+                &mut self.render_pass
+            }
+
+            #(#vertex_setters)*
+
+            #(#bind_group_setters)*
+        }
+        impl<'rp> EnhancedRenderPass<'rp, #(#type_args_all_ready),*> {
+            pub fn draw(&mut self, vertices: std::ops::Range<u32>, instances: std::ops::Range<u32>) {
+                self.render_pass.draw(vertices, instances);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Require initialization of the RenderPass

- bind group
- vertex buffers

I feel like there is a lot of potential along these lines (as wide as the RenderPass set of methods, almost). So we just have to decide how much the generated shader can tell us, and where we want to draw the line. 

For example, we might be able to make a struct dedicated to each RenderPipeline so that a only a correctly typed RenderPipeline can be set on the EnhancedRenderPass. However we'd also need a way to reuse the inner RenderPass for multiple different RenderPipelines. It should be possible, but is not in this implementation yet. 