### PR TITLE
update naga to 0.12

### DIFF
--- a/wgsl_to_wgpu/Cargo.toml
+++ b/wgsl_to_wgpu/Cargo.toml
@@ -10,7 +10,7 @@ readme = "../README.md"
 edition = "2021"
 
 [dependencies]
-naga = { version = "0.11.0", features = ["wgsl-in"] }
+naga = { version = "0.12.0", features = ["wgsl-in"] }
 wgpu-types = "0.16.0"
 syn = "1.0"
 quote = "1.0"

--- a/wgsl_to_wgpu/src/wgsl.rs
+++ b/wgsl_to_wgpu/src/wgsl.rs
@@ -97,6 +97,8 @@ pub fn rust_type(module: &naga::Module, ty: &naga::Type, format: MatrixVectorTyp
             quote!(#name)
         }
         naga::TypeInner::BindingArray { base: _, size: _ } => todo!(),
+        naga::TypeInner::AccelerationStructure => todo!(),
+        naga::TypeInner::RayQuery => todo!(),
     }
 }
 


### PR DESCRIPTION
Wgpu 0.16 uses naga 0.12.

I bumped into an incompatibility between 0.11 and 0.12: type aliases are now called `alias`, and not `type`.