### PR TITLE
Update to wgpu 22.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Breaking changes in the generated code will be considered as breaking changes wh
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+* Update dependencies for wgpu 22.0.0.
+
 ## 0.8.1 - 2024-06-29
 ### Added
 * Added support for a single push constant range used by all shader stages.

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2021"
 
 [dependencies]
 winit = "0.30"
-wgpu = "0.20"
+wgpu = "22.0.0"
 futures = "0.3"
-bytemuck = { version = "1.13", features = ["derive"] }
-encase = { version = "0.8.0", features = ["glam"] }
-glam = { version = "0.27.0", features = ["bytemuck"] }
+bytemuck = { version = "1.16", features = ["derive"] }
+encase = { version = "0.9.0", features = ["glam"] }
+glam = { version = "0.28.0", features = ["bytemuck"] }
 
 [build-dependencies]
 wgsl_to_wgpu = { path = "../wgsl_to_wgpu" }

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -52,6 +52,7 @@ impl State {
                         max_push_constant_size: 128,
                         ..Default::default()
                     },
+                    memory_hints: Default::default(),
                 },
                 None,
             )
@@ -91,6 +92,7 @@ impl State {
             depth_stencil: None,
             multisample: wgpu::MultisampleState::default(),
             multiview: None,
+            cache: Default::default()
         });
 
         // Create a gradient texture.

--- a/wgsl_to_wgpu/Cargo.toml
+++ b/wgsl_to_wgpu/Cargo.toml
@@ -10,8 +10,8 @@ readme = "../README.md"
 edition = "2021"
 
 [dependencies]
-naga = { version = "0.20.0", features = ["wgsl-in"] }
-wgpu-types = "0.20.0"
+naga = { version = "22.0.0", features = ["wgsl-in"] }
+wgpu-types = "22.0.0"
 syn = "2.0"
 quote = "1.0"
 proc-macro2 = "1.0"
@@ -20,5 +20,5 @@ thiserror = "1.0"
 case = "1.0"
 
 [dev-dependencies]
-indoc = "1.0"
+indoc = "2.0"
 pretty_assertions = "1.4"

--- a/wgsl_to_wgpu/src/lib.rs
+++ b/wgsl_to_wgpu/src/lib.rs
@@ -343,6 +343,7 @@ fn create_compute_pipeline(e: &naga::EntryPoint) -> TokenStream {
                 module: &module,
                 entry_point: #entry_point,
                 compilation_options: Default::default(),
+                cache: Default::default(),
             })
         }
     }
@@ -848,6 +849,7 @@ mod test {
                                     module: &module,
                                     entry_point: "main1",
                                     compilation_options: Default::default(),
+                                    cache: Default::default(),
                                 },
                             )
                     }
@@ -863,6 +865,7 @@ mod test {
                                     module: &module,
                                     entry_point: "main2",
                                     compilation_options: Default::default(),
+                                    cache: Default::default(),
                                 },
                             )
                     }


### PR DESCRIPTION
Updates this crate to wgpu 22.0.0. This seems to have been a quite straightforward upgrade.