### PR TITLE
Support scalar, vector, and matrix bindings

### DIFF
--- a/wgsl_to_wgpu/src/lib.rs
+++ b/wgsl_to_wgpu/src/lib.rs
@@ -548,7 +548,9 @@ mod test {
                 f: vec4<f32>
             };
             @group(0) @binding(0) var<uniform> a: A;
-            @group(1) @binding(0) var<uniform> b: A;
+            @group(1) @binding(0) var<uniform> b: f32;
+            @group(2) @binding(0) var<uniform> c: vec4<f32>;
+            @group(3) @binding(0) var<uniform> d: mat4x4<f32>;
 
             @vertex
             fn vs_main() {}


### PR DESCRIPTION
This change adds support for generating bindings to scalar, vector, and matrix uniforms to support shader code like:

```
@group(0) @binding(0) var<uniform> s: f32;
@group(0) @binding(1) var<uniform> v: vec4<f32>;
@group(0) @binding(2) var<uniform> m: mat4x4<f32>;
```

It also expands upon the error message for unsupported types to make it clearer which binding is unsupported and why.