### PR TITLE
Support texture arrays

### DIFF
--- a/wgsl_to_wgpu/src/bindgroup.rs
+++ b/wgsl_to_wgpu/src/bindgroup.rs
@@ -211,12 +211,20 @@ fn bind_group_layout_entry(
                 min_binding_size: None,
             })
         }
-        naga::TypeInner::Image { dim, class, .. } => {
-            let view_dim = match dim {
-                naga::ImageDimension::D1 => quote!(wgpu::TextureViewDimension::D1),
-                naga::ImageDimension::D2 => quote!(wgpu::TextureViewDimension::D2),
-                naga::ImageDimension::D3 => quote!(wgpu::TextureViewDimension::D3),
-                naga::ImageDimension::Cube => quote!(wgpu::TextureViewDimension::Cube),
+        naga::TypeInner::Image {
+            dim,
+            arrayed,
+            class,
+            ..
+        } => {
+            let view_dim = match (dim, arrayed) {
+                (naga::ImageDimension::D1, false) => quote!(wgpu::TextureViewDimension::D1),
+                (naga::ImageDimension::D2, false) => quote!(wgpu::TextureViewDimension::D2),
+                (naga::ImageDimension::D2, true) => quote!(wgpu::TextureViewDimension::D2Array),
+                (naga::ImageDimension::D3, false) => quote!(wgpu::TextureViewDimension::D3),
+                (naga::ImageDimension::Cube, false) => quote!(wgpu::TextureViewDimension::Cube),
+                (naga::ImageDimension::Cube, true) => quote!(wgpu::TextureViewDimension::CubeArray),
+                _ => panic!("Unsupported image dimension {dim:?}, arrayed = {arrayed}"),
             };
 
             match class {

--- a/wgsl_to_wgpu/src/data/bindgroup/vertex_fragment.rs
+++ b/wgsl_to_wgpu/src/data/bindgroup/vertex_fragment.rs
@@ -14,6 +14,8 @@ pub mod bind_groups {
         pub storage_tex_read_write: &'a wgpu::TextureView,
         pub color_texture_msaa: &'a wgpu::TextureView,
         pub depth_texture_msaa: &'a wgpu::TextureView,
+        pub color_texture_array_2d: &'a wgpu::TextureView,
+        pub color_texture_array_cube: &'a wgpu::TextureView,
     }
     const LAYOUT_DESCRIPTOR0: wgpu::BindGroupLayoutDescriptor = wgpu::BindGroupLayoutDescriptor {
         label: Some("LayoutDescriptor0"),
@@ -120,6 +122,26 @@ pub mod bind_groups {
                 },
                 count: None,
             },
+            wgpu::BindGroupLayoutEntry {
+                binding: 11,
+                visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+                ty: wgpu::BindingType::Texture {
+                    sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                    view_dimension: wgpu::TextureViewDimension::D2Array,
+                    multisampled: false,
+                },
+                count: None,
+            },
+            wgpu::BindGroupLayoutEntry {
+                binding: 12,
+                visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+                ty: wgpu::BindingType::Texture {
+                    sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                    view_dimension: wgpu::TextureViewDimension::CubeArray,
+                    multisampled: false,
+                },
+                count: None,
+            },
         ],
     };
     impl BindGroup0 {
@@ -176,6 +198,18 @@ pub mod bind_groups {
                     wgpu::BindGroupEntry {
                         binding: 10,
                         resource: wgpu::BindingResource::TextureView(bindings.depth_texture_msaa),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 11,
+                        resource: wgpu::BindingResource::TextureView(
+                            bindings.color_texture_array_2d,
+                        ),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 12,
+                        resource: wgpu::BindingResource::TextureView(
+                            bindings.color_texture_array_cube,
+                        ),
                     },
                 ],
                 label: Some("BindGroup0"),

--- a/wgsl_to_wgpu/src/data/bindgroup/vertex_fragment.wgsl
+++ b/wgsl_to_wgpu/src/data/bindgroup/vertex_fragment.wgsl
@@ -26,6 +26,11 @@ var color_texture_msaa: texture_multisampled_2d<f32>;
 @group(0) @binding(10)
 var depth_texture_msaa: texture_depth_multisampled_2d;
 
+@group(0) @binding(11)
+var color_texture_array_2d: texture_2d_array<f32>;
+@group(0) @binding(12)
+var color_texture_array_cube: texture_cube_array<f32>;
+
 @group(1) @binding(0) var<uniform> transforms: Transforms;
 @group(1) @binding(1) var<uniform> scalar: f32;
 @group(1) @binding(2) var<uniform> vector: vec4<f32>;


### PR DESCRIPTION
This enables support for  `texture_2d_array` and `texture_cube_array` bindings. This completes the supported texture types in the current [WGSL spec](https://www.w3.org/TR/WGSL/#sampled-texture-type).