### PR TITLE
Follow function call statements

### DIFF
--- a/wgsl_to_wgpu/tests/create_shader_module.rs
+++ b/wgsl_to_wgpu/tests/create_shader_module.rs
@@ -18,6 +18,7 @@ fn vertex_entries() {
 
 #[test]
 fn shader_stage_collection() {
+    // Check the visibility: wgpu::ShaderStages::COMPUTE
     let actual = wgsl_to_wgpu::create_shader_module(
         include_str!("wgsl/shader_stage_collection.wgsl"),
         "shader.wgsl",
@@ -29,6 +30,5 @@ fn shader_stage_collection() {
     )
     .unwrap();
 
-    let bad_fragment = actual.find("visibility: wgpu::ShaderStages::NONE");
-    assert_eq!(bad_fragment, None, "Shader was {}", actual);
+    assert_eq!(include_str!("output/shader_stage_collection.rs"), actual);
 }

--- a/wgsl_to_wgpu/tests/create_shader_module.rs
+++ b/wgsl_to_wgpu/tests/create_shader_module.rs
@@ -15,3 +15,20 @@ fn vertex_entries() {
 
     assert_eq!(include_str!("output/vertex_entries.rs"), actual);
 }
+
+#[test]
+fn shader_stage_collection() {
+    let actual = wgsl_to_wgpu::create_shader_module(
+        include_str!("wgsl/shader_stage_collection.wgsl"),
+        "shader.wgsl",
+        wgsl_to_wgpu::WriteOptions {
+            rustfmt: true,
+            derive_encase_host_shareable: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let bad_fragment = actual.find("visibility: wgpu::ShaderStages::NONE");
+    assert_eq!(bad_fragment, None, "Shader was {}", actual);
+}

--- a/wgsl_to_wgpu/tests/output/shader_stage_collection.rs
+++ b/wgsl_to_wgpu/tests/output/shader_stage_collection.rs
@@ -1,0 +1,115 @@
+pub mod bind_groups {
+    #[derive(Debug)]
+    pub struct BindGroup0(wgpu::BindGroup);
+    #[derive(Debug)]
+    pub struct BindGroupLayout0<'a> {
+        pub counter: wgpu::BufferBinding<'a>,
+    }
+    const LAYOUT_DESCRIPTOR0: wgpu::BindGroupLayoutDescriptor = wgpu::BindGroupLayoutDescriptor {
+        label: Some("LayoutDescriptor0"),
+        entries: &[wgpu::BindGroupLayoutEntry {
+            binding: 0,
+            visibility: wgpu::ShaderStages::COMPUTE,
+            ty: wgpu::BindingType::Buffer {
+                ty: wgpu::BufferBindingType::Storage { read_only: false },
+                has_dynamic_offset: false,
+                min_binding_size: None,
+            },
+            count: None,
+        }],
+    };
+    impl BindGroup0 {
+        pub fn get_bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLayout {
+            device.create_bind_group_layout(&LAYOUT_DESCRIPTOR0)
+        }
+        pub fn from_bindings(device: &wgpu::Device, bindings: BindGroupLayout0) -> Self {
+            let bind_group_layout = device.create_bind_group_layout(&LAYOUT_DESCRIPTOR0);
+            let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+                layout: &bind_group_layout,
+                entries: &[wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::Buffer(bindings.counter),
+                }],
+                label: Some("BindGroup0"),
+            });
+            Self(bind_group)
+        }
+        pub fn set<P: SetBindGroup>(&self, pass: &mut P) {
+            pass.set_bind_group(0, &self.0, &[]);
+        }
+    }
+    #[derive(Debug, Copy, Clone)]
+    pub struct BindGroups<'a> {
+        pub bind_group0: &'a BindGroup0,
+    }
+    impl<'a> BindGroups<'a> {
+        pub fn set<P: SetBindGroup>(&self, pass: &mut P) {
+            self.bind_group0.set(pass);
+        }
+    }
+    pub trait SetBindGroup {
+        fn set_bind_group(
+            &mut self,
+            index: u32,
+            bind_group: &wgpu::BindGroup,
+            offsets: &[wgpu::DynamicOffset],
+        );
+    }
+    impl SetBindGroup for wgpu::ComputePass<'_> {
+        fn set_bind_group(
+            &mut self,
+            index: u32,
+            bind_group: &wgpu::BindGroup,
+            offsets: &[wgpu::DynamicOffset],
+        ) {
+            self.set_bind_group(index, bind_group, offsets);
+        }
+    }
+    impl SetBindGroup for wgpu::RenderPass<'_> {
+        fn set_bind_group(
+            &mut self,
+            index: u32,
+            bind_group: &wgpu::BindGroup,
+            offsets: &[wgpu::DynamicOffset],
+        ) {
+            self.set_bind_group(index, bind_group, offsets);
+        }
+    }
+}
+pub fn set_bind_groups<P: bind_groups::SetBindGroup>(
+    pass: &mut P,
+    bind_group0: &bind_groups::BindGroup0,
+) {
+    bind_group0.set(pass);
+}
+pub mod compute {
+    pub const MAIN_WORKGROUP_SIZE: [u32; 3] = [1, 1, 1];
+    pub fn create_main_pipeline(device: &wgpu::Device) -> wgpu::ComputePipeline {
+        let module = super::create_shader_module(device);
+        let layout = super::create_pipeline_layout(device);
+        device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("Compute Pipeline main"),
+            layout: Some(&layout),
+            module: &module,
+            entry_point: Some("main"),
+            compilation_options: Default::default(),
+            cache: Default::default(),
+        })
+    }
+}
+pub const ENTRY_MAIN: &str = "main";
+pub const SOURCE: &str = include_str!("shader.wgsl");
+pub fn create_shader_module(device: &wgpu::Device) -> wgpu::ShaderModule {
+    let source = std::borrow::Cow::Borrowed(SOURCE);
+    device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: None,
+        source: wgpu::ShaderSource::Wgsl(source),
+    })
+}
+pub fn create_pipeline_layout(device: &wgpu::Device) -> wgpu::PipelineLayout {
+    device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: None,
+        bind_group_layouts: &[&bind_groups::BindGroup0::get_bind_group_layout(device)],
+        push_constant_ranges: &[],
+    })
+}

--- a/wgsl_to_wgpu/tests/wgsl/shader_stage_collection.wgsl
+++ b/wgsl_to_wgpu/tests/wgsl/shader_stage_collection.wgsl
@@ -1,0 +1,11 @@
+@group(0) @binding(0)
+var<storage, read_write> counter : array<atomic<u32>, 1>;
+
+fn add_one() {
+    atomicAdd(&counter[0], 1u);
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn main() {
+  add_one();
+}


### PR DESCRIPTION
I ran into this bug, noticed the todo comment, and fixed it :)

Essentially WGSL has both function calls as expressions `a * func() + b` and function calls as statements `foobar();`. And naga apparently separates the two.