### PR TITLE
Fix incorrect encase derive attribute

### DIFF
--- a/wgsl_to_wgpu/src/snapshots/create_shader_module_compute_overrides.snap
+++ b/wgsl_to_wgpu/src/snapshots/create_shader_module_compute_overrides.snap
@@ -159,9 +159,8 @@ pub fn create_pipeline_layout(device: &wgpu::Device) -> wgpu::PipelineLayout {
             },
         )
 }
-#[derive(Debug, Clone, PartialEq, encase::ShaderType)]
-pub struct RtsStruct {
-    pub other_data: i32,
-    #[shader(size(runtime))]
-    pub the_array: Vec<u32>,
+#[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct Uniforms {
+    pub color_rgb: [f32; 3],
 }


### PR DESCRIPTION
This fixes my error from #77, this is an example of why tests should compile check bindings