### PR TITLE
fix `bind_group_layouts` output

### DIFF
--- a/wgsl_to_wgpu/src/lib.rs
+++ b/wgsl_to_wgpu/src/lib.rs
@@ -532,7 +532,7 @@ where
         .keys()
         .map(|group_no| {
             let group = indexed_name_to_ident("BindGroup", *group_no);
-            quote!(Some(&bind_groups::#group::get_bind_group_layout(device)))
+            quote!(&bind_groups::#group::get_bind_group_layout(device))
         })
         .collect();
 


### PR DESCRIPTION
This patch fixes this error in newer wgsl versions in `PipelineLayoutDescriptor.bind_group_layouts`
```sh
Some(&bind_groups::BindGroup0::get_bind_group_layout(device)),
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&BindGroupLayout`, found `Option<&BindGroupLayout>`
    |
    = note: expected reference `&wgpu::BindGroupLayout`
                    found enum `Option<&wgpu::BindGroupLayout>`
```